### PR TITLE
fix: Visual bug fix, and 'App Details' change

### DIFF
--- a/lib/components/SubbedMarketplaceAppCards/styles.ts
+++ b/lib/components/SubbedMarketplaceAppCards/styles.ts
@@ -3,6 +3,7 @@ import { makeStyles } from '@apisuite/fe-base'
 export default makeStyles((theme) => ({
   allSubbedMarketplaceAppsContainer: {
     display: 'flex',
+    marginTop: 40,
   },
 
   browseMarketplaceAppsButton: {

--- a/lib/pages/AppDetails/AppDetails.tsx
+++ b/lib/pages/AppDetails/AppDetails.tsx
@@ -295,11 +295,11 @@ const AppDetails: React.FC<AppDetailsProps> = ({
                   : '...'}
               </h1>
 
-              <p className={classes.appDescription}>
-                {selectedAppDetails && selectedAppDetails.shortDescription
-                  ? selectedAppDetails.shortDescription
-                  : t('appMarketplace.appDetails.noShortDescription')}
-              </p>
+              {selectedAppDetails && selectedAppDetails.shortDescription && (
+                <p className={classes.appDescription}>
+                  {selectedAppDetails.shortDescription}
+                </p>
+              )}
 
               <div className={classes.appLabelsContainer}>
                 {selectedAppDetails && selectedAppDetails.labels.length ? (
@@ -318,8 +318,8 @@ const AppDetails: React.FC<AppDetailsProps> = ({
               </div>
 
               {/* The following condition is to be taken as explicit - meaning, we need to
-              explicitly check if the length of 'imagesArray' is, indeed, anything other
-              than zero. Not doing so will result in unwanted consequences. */}
+explicitly check if the length of 'imagesArray' is, indeed, anything other
+than zero. Not doing so will result in unwanted consequences. */}
               {imagesArray.length !== 0 && (
                 <ImageGallery
                   additionalClass={classes.appImageGallery}


### PR DESCRIPTION
Fixed a visual bug on the 'Services' view (cards getting themselves on top of the "Browse marketplace" button), and made a change requested by fellow designers in the 'App Details' view (removing the "No short description provided" text).

<img width="371" alt="Screenshot 2021-06-01 at 13 50 26" src="https://user-images.githubusercontent.com/67902809/120326206-63eef680-c2e0-11eb-97bd-de0edd693f0f.png">
