### PR TITLE
fix: Labels input field now locks up based on the user's role

### DIFF
--- a/lib/components/MarketplaceAppVisibility/MarketplaceAppVisibility.tsx
+++ b/lib/components/MarketplaceAppVisibility/MarketplaceAppVisibility.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import { TextField, useTranslation } from '@apisuite/fe-base'
+import clsx from 'clsx'
 import RadioButtonCheckedRoundedIcon from '@material-ui/icons/RadioButtonCheckedRounded'
 import RadioButtonUncheckedRoundedIcon from '@material-ui/icons/RadioButtonUncheckedRounded'
 
@@ -10,6 +11,7 @@ const MarketplaceAppVisibility: React.FC<MarketplaceAppVisibilityProps> = ({
   formState,
   handleAppVisibility,
   handleChange,
+  userRoleID,
 }) => {
   const classes = useStyles()
 
@@ -93,7 +95,11 @@ const MarketplaceAppVisibility: React.FC<MarketplaceAppVisibilityProps> = ({
           </p>
 
           <TextField
-            className={classes.inputFields}
+            // This input field will be disabled when the user is NOT an admin (i.e., role ID is anything other than 2)
+            className={clsx(classes.inputFields, {
+              [classes.disabledInputField]: userRoleID !== 2,
+            })}
+            disabled={userRoleID !== 2}
             fullWidth
             helperText={t('appSettings.labelsFieldHelperText')}
             label={t('appSettings.labelsFieldLabel')}

--- a/lib/components/MarketplaceAppVisibility/MarketplaceAppVisibility.tsx
+++ b/lib/components/MarketplaceAppVisibility/MarketplaceAppVisibility.tsx
@@ -11,7 +11,7 @@ const MarketplaceAppVisibility: React.FC<MarketplaceAppVisibilityProps> = ({
   formState,
   handleAppVisibility,
   handleChange,
-  userRoleID,
+  userRole,
 }) => {
   const classes = useStyles()
 
@@ -95,11 +95,10 @@ const MarketplaceAppVisibility: React.FC<MarketplaceAppVisibilityProps> = ({
           </p>
 
           <TextField
-            // This input field will be disabled when the user is NOT an admin (i.e., role ID is anything other than 2)
             className={clsx(classes.inputFields, {
-              [classes.disabledInputField]: userRoleID !== 2,
+              [classes.disabledInputField]: userRole !== 'admin',
             })}
-            disabled={userRoleID !== 2}
+            disabled={userRole !== 'admin'}
             fullWidth
             helperText={t('appSettings.labelsFieldHelperText')}
             label={t('appSettings.labelsFieldLabel')}

--- a/lib/components/MarketplaceAppVisibility/index.ts
+++ b/lib/components/MarketplaceAppVisibility/index.ts
@@ -1,1 +1,9 @@
-export { default } from './MarketplaceAppVisibility'
+import { connect } from 'react-redux'
+
+import MarketplaceAppVisibility from './MarketplaceAppVisibility'
+
+export const mapStateToProps = ({ profile }) => ({
+  userRoleID: profile.profile.current_org.role.id,
+})
+
+export default connect(mapStateToProps, null)(MarketplaceAppVisibility)

--- a/lib/components/MarketplaceAppVisibility/index.ts
+++ b/lib/components/MarketplaceAppVisibility/index.ts
@@ -3,7 +3,7 @@ import { connect } from 'react-redux'
 import MarketplaceAppVisibility from './MarketplaceAppVisibility'
 
 export const mapStateToProps = ({ profile }) => ({
-  userRoleID: profile.profile.current_org.role.id,
+  userRole: profile.profile.current_org.role.name,
 })
 
 export default connect(mapStateToProps, null)(MarketplaceAppVisibility)

--- a/lib/components/MarketplaceAppVisibility/styles.ts
+++ b/lib/components/MarketplaceAppVisibility/styles.ts
@@ -9,6 +9,21 @@ export default makeStyles((theme) => ({
     marginBottom: 40,
   },
 
+  disabledInputField: {
+    // Disabled text field's label styles
+    '& > label': {
+      color: 'rgba(0, 0, 0, 0.26) !important',
+    },
+
+    // Disabled text field's input text styles
+    '& .MuiInputBase-root': {
+      '& .MuiInputBase-input': {
+        backgroundColor: 'rgba(0, 0, 0, 0.12)',
+        borderRadius: 4,
+      },
+    },
+  },
+
   inputFields: {
     marginBottom: 25,
     marginTop: 0,

--- a/lib/components/MarketplaceAppVisibility/types.ts
+++ b/lib/components/MarketplaceAppVisibility/types.ts
@@ -2,6 +2,7 @@ export type MarketplaceAppVisibilityProps = {
   formState: FormState
   handleAppVisibility: (selectedAppVisibility: string) => void
   handleChange: (changeEvent) => void
+  userRoleID: number
 }
 
 export interface FormState {

--- a/lib/components/MarketplaceAppVisibility/types.ts
+++ b/lib/components/MarketplaceAppVisibility/types.ts
@@ -2,7 +2,7 @@ export type MarketplaceAppVisibilityProps = {
   formState: FormState
   handleAppVisibility: (selectedAppVisibility: string) => void
   handleChange: (changeEvent) => void
-  userRoleID: number
+  userRole: string
 }
 
 export interface FormState {


### PR DESCRIPTION
The "Labels" input field on the app's overlay now locks up based on the user's role.