### PR TITLE
fix: Changed the Marketplace header's translation to use portal name interpolation

### DIFF
--- a/lib/pages/Marketplace/Marketplace.tsx
+++ b/lib/pages/Marketplace/Marketplace.tsx
@@ -684,9 +684,11 @@ const Marketplace: React.FC = () => {
           {/* 1.1 - Header's title & search field */}
           <div className={classes.appMarketHeaderTitleAndSearchField}>
             <Typography variant="h1" className={classes.appMarketHeaderTitle}>
-              <>{t('appMarketplace.headerTitlePartOne')} </>
-              <>{portalName} </>
-              <>{t('appMarketplace.headerTitlePartTwo')}</>
+              <>
+                {t('appMarketplace.headerTitle', {
+                  portalName,
+                })}
+              </>
             </Typography>
 
             {!!allMarketplaceApps.length && (

--- a/lib/translations/en-US.json
+++ b/lib/translations/en-US.json
@@ -21,8 +21,7 @@
         "invalidURL": "The provided URL is not valid."
       },
       "appMarketplace": {
-        "headerTitlePartOne": "Explore the",
-        "headerTitlePartTwo": "Marketplace",
+        "headerTitle": "Explore the {{portalName}} Marketplace",
         "searchForAppsTextField": "Search for apps",
         "noAppsTitle": "There are no applications in our Marketplace!",
         "noAppsSubtitlePartOne": "We don't have any applications available... yet!",


### PR DESCRIPTION
The goal is to be possible to edit the whole header title as one unique field, instead of what we had previously ("Explore the" in one translation, and "Marketplace" in another).